### PR TITLE
Load libraries for unknown function warnings

### DIFF
--- a/gsnip.el
+++ b/gsnip.el
@@ -29,6 +29,10 @@
 
 (require 'cl-lib)
 (require 'seq)
+(require 'json)
+(require 'subr-x)
+(require 'parse-time)
+(require 'url-http)
 
 (require 'aio)
 (require 'log4e)


### PR DESCRIPTION
```
In end of data:
gsnip.el:391:1:Warning: the following functions are not known to be defined:
    json-read-from-string, string-trim, url-http-parse-response,
    json-encode, parse-iso8601-time-string
```